### PR TITLE
Access page contents via the main slot

### DIFF
--- a/mw_api_client/page.py
+++ b/mw_api_client/page.py
@@ -131,6 +131,7 @@ class Page(object):
             'prop': "revisions",
             'rvprop': "content|timestamp",
             'rvlimit': "1",
+            'rvslots': 'main'
         })
         missingq = False
         try:
@@ -145,7 +146,7 @@ class Page(object):
             raise WikiError.notfound('The page does not exist.')
         self._lasttimestamp = time.mktime(time.strptime(data['timestamp'],
                                                         '%Y-%m-%dT%H:%M:%SZ'))
-        self.content = data['*']
+        self.content = data['slots']['main']['*']
         return self.content
 
     @_CachedAttribute


### PR DESCRIPTION
This just removes a warning the current api usage prints on more recent mediawiki versions. Mediawiki has added a mechanism for tagging different revisions as a certain piece of content, but everything still just uses "main"